### PR TITLE
Add add_wms_layer method, test and example to the chartops Map class

### DIFF
--- a/chartops/chartops.py
+++ b/chartops/chartops.py
@@ -2,7 +2,7 @@ import geopandas as gpd
 from typing import Union, Optional, Tuple
 from pathlib import Path
 from ipyleaflet import Map as iPyLeafletMap
-from ipyleaflet import LayersControl, basemap_to_tiles, GeoJSON, ImageOverlay
+from ipyleaflet import LayersControl, basemap_to_tiles, GeoJSON, ImageOverlay, WMSLayer
 from chartops import common
 
 
@@ -190,3 +190,54 @@ class Map(iPyLeafletMap):
             self.add(image)
         except Exception as e:
             raise ValueError(f"Failed to add image overlay: {e}")
+
+    def add_wms_layer(
+        self,
+        url: str,
+        layers: str,
+        name: str,
+        format: str,
+        transparent: bool,
+        **kwargs
+    ) -> None:
+        """
+        Add a WMS (Web Map Service) layer to the map.
+
+        Args:
+            url (str): Base URL of the WMS service.
+            layers (str): Comma-separated list of layer names to request from the service.
+            name (str): Name of the layer to show in the map.
+            format (str): Image format for the WMS tiles (e.g., 'image/png').
+            transparent (bool): Whether the WMS tiles should support transparency.
+            **kwargs (dict): Additional keyword arguments passed to the WMSLayer.
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: If any of the required parameters are not of the expected type.
+            ValueError: If the WMS layer cannot be created or added.
+        """
+        if not isinstance(url, str):
+            raise TypeError(f"url must be a string, got {type(url)}")
+        if not isinstance(layers, str):
+            raise TypeError(f"layers must be a string, got {type(layers)}")
+        if not isinstance(name, str):
+            raise TypeError(f"name must be a string, got {type(name)}")
+        if not isinstance(format, str):
+            raise TypeError(f"format must be a string, got {type(format)}")
+        if not isinstance(transparent, bool):
+            raise TypeError(f"transparent must be a boolean, got {type(transparent)}")
+
+        try:
+            wms = WMSLayer(
+                url=url,
+                layers=layers,
+                format=format,
+                transparent=transparent,
+                **kwargs,
+            )
+            wms.name = name
+            self.add(wms)
+        except Exception as e:
+            raise ValueError(f"Failed to add WMS layer: {e}")

--- a/chartops/chartops.py
+++ b/chartops/chartops.py
@@ -192,13 +192,7 @@ class Map(iPyLeafletMap):
             raise ValueError(f"Failed to add image overlay: {e}")
 
     def add_wms_layer(
-        self,
-        url: str,
-        layers: str,
-        name: str,
-        format: str,
-        transparent: bool,
-        **kwargs
+        self, url: str, layers: str, name: str, format: str, transparent: bool, **kwargs
     ) -> None:
         """
         Add a WMS (Web Map Service) layer to the map.

--- a/docs/examples/chartops.ipynb
+++ b/docs/examples/chartops.ipynb
@@ -9,9 +9,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR: Invalid requirement: 'chartops/chartops.py'\n",
+      "\n",
+      "[notice] A new release of pip available: 22.2.1 -> 25.1.1\n",
+      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+     ]
+    }
+   ],
    "source": [
     "# %pip install -q chartops\n",
     "%pip install -q chartops/chartops.py"
@@ -19,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,9 +46,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "082549acdc1447de9a159a8c758d824e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[34.5, 18.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out…"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "map = Map(center=[34.5, 18.0], zoom=5)\n",
     "map"
@@ -38,9 +72,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "174130a31bca420b8ca311b85b3d00fa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[34.5, 18.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out…"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "map_with_basemap = Map(center=[34.5, 18.0], zoom=5)\n",
     "map_with_basemap.add_basemap(\"OpenTopoMap\")\n",
@@ -49,9 +99,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7a322f352ed64fba812813b60107e381",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[34.5, 18.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out…"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "map_with_layer_controls = Map(center=[34.5, 18.0], zoom=5)\n",
     "map_with_layer_controls.add_layer_control()\n",
@@ -60,9 +126,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ddf3333120194ae486ad4c45ebeeaa85",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[34.5, 18.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out…"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "map_with_vector = Map(center=[34.5, 18.0], zoom=5)\n",
     "map_with_vector.add_vector(\n",
@@ -74,9 +156,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cf04b0c33aa249de8c0798901794e7ee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[34.5, 18.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out…"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "map_with_multiple_features = Map(center=[34.5, 18.0], zoom=5)\n",
     "map_with_multiple_features.add_basemap(\"Esri.WorldImagery\")\n",
@@ -90,9 +188,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d633aa82fee44aeaba36faa0d0ffd73e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[37.630466999999996, -119.03021849999999], controls=(ZoomControl(options=['position', 'zoom_in_text…"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "map_with_raster = Map(center=[34.5, 18.0], zoom=5)\n",
     "map_with_raster.add_raster(\n",
@@ -109,15 +223,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ad782592799d45058e9849832288dd51",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[28.0, -114.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_o…"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "map_with_image = Map(center=[28.0, -114.0], zoom=5)\n",
     "map_with_image.add_image(\n",
     "    url=\"https://i.imgur.com/06Q1fSz.png\", bounds=((13, -130), (32, -100)), opacity=0.5\n",
     ")\n",
     "map_with_image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7139944d2f6742bf847d0de1736f8f07",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[28.0, -114.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_o…"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "map_with_wms = Map(center=[28.0, -114.0], zoom=5)\n",
+    "map_with_wms.add_wms_layer(\n",
+    "    \"http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi\",\n",
+    "    \"nexrad-n0r-900913\",\n",
+    "    \"Test\",\n",
+    "    \"image/png\",\n",
+    "    True\n",
+    ")\n",
+    "map_with_wms"
    ]
   }
  ],

--- a/docs/examples/chartops.ipynb
+++ b/docs/examples/chartops.ipynb
@@ -9,27 +9,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "ERROR: Invalid requirement: 'chartops/chartops.py'\n",
-      "\n",
-      "[notice] A new release of pip available: 22.2.1 -> 25.1.1\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# %pip install -q chartops\n",
     "%pip install -q chartops/chartops.py"
@@ -37,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,25 +28,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "082549acdc1447de9a159a8c758d824e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[34.5, 18.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out…"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "map = Map(center=[34.5, 18.0], zoom=5)\n",
     "map"
@@ -72,25 +38,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "174130a31bca420b8ca311b85b3d00fa",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[34.5, 18.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out…"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "map_with_basemap = Map(center=[34.5, 18.0], zoom=5)\n",
     "map_with_basemap.add_basemap(\"OpenTopoMap\")\n",
@@ -99,25 +49,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7a322f352ed64fba812813b60107e381",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[34.5, 18.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out…"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "map_with_layer_controls = Map(center=[34.5, 18.0], zoom=5)\n",
     "map_with_layer_controls.add_layer_control()\n",
@@ -126,25 +60,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ddf3333120194ae486ad4c45ebeeaa85",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[34.5, 18.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out…"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "map_with_vector = Map(center=[34.5, 18.0], zoom=5)\n",
     "map_with_vector.add_vector(\n",
@@ -156,25 +74,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cf04b0c33aa249de8c0798901794e7ee",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[34.5, 18.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out…"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "map_with_multiple_features = Map(center=[34.5, 18.0], zoom=5)\n",
     "map_with_multiple_features.add_basemap(\"Esri.WorldImagery\")\n",
@@ -188,25 +90,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d633aa82fee44aeaba36faa0d0ffd73e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[37.630466999999996, -119.03021849999999], controls=(ZoomControl(options=['position', 'zoom_in_text…"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "map_with_raster = Map(center=[34.5, 18.0], zoom=5)\n",
     "map_with_raster.add_raster(\n",
@@ -223,25 +109,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ad782592799d45058e9849832288dd51",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[28.0, -114.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_o…"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "map_with_image = Map(center=[28.0, -114.0], zoom=5)\n",
     "map_with_image.add_image(\n",
@@ -252,25 +122,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7139944d2f6742bf847d0de1736f8f07",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[28.0, -114.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_o…"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "map_with_wms = Map(center=[28.0, -114.0], zoom=5)\n",
     "map_with_wms.add_wms_layer(\n",
@@ -278,7 +132,7 @@
     "    \"nexrad-n0r-900913\",\n",
     "    \"Test\",\n",
     "    \"image/png\",\n",
-    "    True\n",
+    "    True,\n",
     ")\n",
     "map_with_wms"
    ]

--- a/tests/test_chartops.py
+++ b/tests/test_chartops.py
@@ -11,7 +11,7 @@ import pandas as pd
 import geopandas as gpd
 from pathlib import Path
 from chartops import chartops
-from ipyleaflet import LayersControl, GeoJSON, ImageOverlay
+from ipyleaflet import LayersControl, GeoJSON, ImageOverlay, WMSLayer
 from unittest.mock import patch
 
 
@@ -251,3 +251,57 @@ class TestChartops(unittest.TestCase):
         bounds = ((-90, -180), (90, 180))
         with self.assertRaises(FileNotFoundError):
             self.map.add_image(path, bounds=bounds, opacity=0.5)
+
+    def test_add_wms_layer_valid(self):
+        url = "http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi"
+        layers = "nexrad-n0r-900913"
+        name = "Test"
+        format = "image/png"
+        transparent = False
+
+        self.map.add_wms_layer(url, layers, name, format, transparent)
+        wms_layer = self.map.layers[-1]
+        self.assertIsInstance(wms_layer, WMSLayer)
+        self.assertEqual(wms_layer.name, name)
+
+    def test_add_wms_layer_invalid_url_type(self):
+        with self.assertRaises(TypeError):
+            self.map.add_wms_layer(
+                url=123, layers="layer", name="Layer", format="image/png", transparent=True
+            )
+
+    def test_add_wms_layer_invalid_layers_type(self):
+        with self.assertRaises(TypeError):
+            self.map.add_wms_layer(
+                url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi", layers=123, name="Layer", format="image/png", transparent=True
+            )
+
+    def test_add_wms_layer_invalid_name_type(self):
+        with self.assertRaises(TypeError):
+            self.map.add_wms_layer(
+                url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi", layers="layer", name=123, format="image/png", transparent=True
+            )
+
+    def test_add_wms_layer_invalid_format_type(self):
+        with self.assertRaises(TypeError):
+            self.map.add_wms_layer(
+                url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi", layers="layer", name="Layer", format=123, transparent=True
+            )
+
+    def test_add_wms_layer_invalid_transparent_type(self):
+        with self.assertRaises(TypeError):
+            self.map.add_wms_layer(
+                url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi", layers="layer", name="Layer", format="image/png", transparent="yes"
+            )
+
+    def test_add_wms_layer_failure_simulation(self):
+        with patch("chartops.chartops.WMSLayer", side_effect=Exception("Failed to initialize")):
+            with self.assertRaises(ValueError) as cm:
+                self.map.add_wms_layer(
+                    url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi",
+                    layers="layer",
+                    name="Layer",
+                    format="image/png",
+                    transparent=True,
+                )
+            self.assertIn("Failed to add WMS layer", str(cm.exception))

--- a/tests/test_chartops.py
+++ b/tests/test_chartops.py
@@ -267,35 +267,57 @@ class TestChartops(unittest.TestCase):
     def test_add_wms_layer_invalid_url_type(self):
         with self.assertRaises(TypeError):
             self.map.add_wms_layer(
-                url=123, layers="layer", name="Layer", format="image/png", transparent=True
+                url=123,
+                layers="layer",
+                name="Layer",
+                format="image/png",
+                transparent=True,
             )
 
     def test_add_wms_layer_invalid_layers_type(self):
         with self.assertRaises(TypeError):
             self.map.add_wms_layer(
-                url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi", layers=123, name="Layer", format="image/png", transparent=True
+                url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi",
+                layers=123,
+                name="Layer",
+                format="image/png",
+                transparent=True,
             )
 
     def test_add_wms_layer_invalid_name_type(self):
         with self.assertRaises(TypeError):
             self.map.add_wms_layer(
-                url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi", layers="layer", name=123, format="image/png", transparent=True
+                url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi",
+                layers="layer",
+                name=123,
+                format="image/png",
+                transparent=True,
             )
 
     def test_add_wms_layer_invalid_format_type(self):
         with self.assertRaises(TypeError):
             self.map.add_wms_layer(
-                url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi", layers="layer", name="Layer", format=123, transparent=True
+                url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi",
+                layers="layer",
+                name="Layer",
+                format=123,
+                transparent=True,
             )
 
     def test_add_wms_layer_invalid_transparent_type(self):
         with self.assertRaises(TypeError):
             self.map.add_wms_layer(
-                url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi", layers="layer", name="Layer", format="image/png", transparent="yes"
+                url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi",
+                layers="layer",
+                name="Layer",
+                format="image/png",
+                transparent="yes",
             )
 
     def test_add_wms_layer_failure_simulation(self):
-        with patch("chartops.chartops.WMSLayer", side_effect=Exception("Failed to initialize")):
+        with patch(
+            "chartops.chartops.WMSLayer", side_effect=Exception("Failed to initialize")
+        ):
             with self.assertRaises(ValueError) as cm:
                 self.map.add_wms_layer(
                     url="http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi",


### PR DESCRIPTION
1. Added the `add_wms_layer`method that adds **WMS (Web Map Service) layers** to the `chartops.Map` class
2. Added unit tests for the `add_wms_layer`method
3. Added example for the `add_wms_layer`method in the `chartops.ipynb` file